### PR TITLE
Chore/branch protection workflow and docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Copy to .env and fill with an admin-capable token to run protected operations.
+# NEVER commit the real .env file.
+
+# Fine-grained PAT with Administration: Read and write on this repo
+GH_ADMIN_TOKEN=

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,65 @@
+name: Branch Protection
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  protect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply branch protection to main
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const branch = 'main';
+            // Required checks (must match job names)
+            const checks = [
+              { context: 'check-syntax' },
+              { context: 'profile-dl' },
+              { context: 'validate-units' },
+              { context: 'validate-sosa' },
+              { context: 'validate-skos' },
+              { context: 'validate-prov' }
+            ];
+
+            await github.request('PUT /repos/{owner}/{repo}/branches/{branch}/protection', {
+              owner,
+              repo,
+              branch,
+              required_status_checks: { strict: true, checks },
+              enforce_admins: true,
+              required_pull_request_reviews: {
+                required_approving_review_count: 1,
+                require_code_owner_reviews: false,
+                require_last_push_approval: false
+              },
+              restrictions: null,
+              allow_force_pushes: false,
+              allow_deletions: false,
+              required_linear_history: false,
+              block_creations: false,
+              required_conversation_resolution: true,
+              lock_branch: false
+            });
+            core.info('Branch protection applied to main.');
+      - name: Verify protection
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          script: |
+            const { data } = await github.request('GET /repos/{owner}/{repo}/branches/{branch}/protection', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main'
+            });
+            core.info(`Admins enforced: ${data.enforce_admins}`);
+            core.info(`Required reviews: ${data.required_pull_request_reviews?.required_approving_review_count}`);
+            core.info(`Strict checks: ${data.required_status_checks?.strict}`);
+            core.info(`Checks: ${(data.required_status_checks?.checks || []).map(c => c.context).join(', ')}`);
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build/
 
 # macOS Finder
 .DS_Store
+
+# Local environment overrides (never commit secrets)
+.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,283 @@
+# ODIM‑MH – Engineering Guide for Coding Agents
+
+## Table of Contents
+- Project Overview (quick)
+- First Steps for a New Agent (verification & alignment)
+- Repository Map (key paths)
+- Local Setup (checks first)
+- Workflow: Issues → Branch → PR
+  - Note on public plan
+  - Task selection and user consultation
+- Labels (conventions)
+- Maintaining the Plan (AGENT-PLAN.md)
+- Branch Protection (settings)
+- Ontology Tasks Cheat‑Sheet
+- Ontology Change Checklist (TBox/ABox)
+- Public Website (pre‑w3id)
+- Safety & Boundaries
+- Quick Commands
+- Contacts
+
+This guide sets expectations for coding agents and contributors working on ODIM‑MH. It covers local setup (GitHub CLI auth) and a lightweight, issue‑driven workflow using GitHub Issues and PRs via `gh`.
+
+## Project Overview (quick)
+
+- Aim: represent high‑level digital markers derived from wearable/mobile sensing in health studies. Model how raw measurements become features, how computations are described/attributed, and how results are situated in time and context.
+- Design: DL‑safe core ontology; DL‑safe references to SOSA (observations), SKOS (vocabularies), QUDT (units); separate PROV‑O alignment module.
+- Naming/prefix: public name ODIM‑MH; recommended prefix `odim:` → `http://connectdigitalstudy.com/ontology#` (pending w3id namespace migration).
+- Read next: `docs/ontology-overview.md` (high‑level) and `docs/technical-overview.md` (detailed modeling + standards).
+
+## First Steps for a New Agent (verification & alignment)
+- Confirm environment
+  - `gh auth status` shows logged‑in user (SSH); if not, ask to run `gh auth login`
+  - `docker version` available; if not, confirm whether to proceed without tooling
+  - Run profile and validators to establish baseline; report results succinctly
+- Align on task
+  - Offer 2–4 next steps from `AGENT-PLAN.md` with brief impact; confirm selection with the user
+  - If the task touches the public roadmap, confirm adding/updating an entry in `plan.md` via docs PR first
+- Proceed
+  - Create a short‑lived branch from `main`, open an Issue (if not existing), and begin work per the chosen task
+  - Minimize interruptions; ask only essential clarifications
+
+## Repository Map (key paths)
+
+- Root
+  - `mhm_ontology.owl`: core ontology
+  - `examples.ttl`: example individuals (ABox)
+  - `plan.md`: public plan (authoritative, non‑agentic)
+  - `AGENT-PLAN.md`: agent execution notes (local‑only)
+- Vocabularies: `vocab/` (SKOS schemes + tags)
+- Queries: `queries/` (`prov_*.rq`, `sosa_*.rq`, `units_*.rq`, `skos_*.rq`)
+- Alignments: `alignments/mhm-prov-align.owl`
+- Tooling: `tooling/` (Dockerfile, run_ontology_tools.sh)
+- Docs: `docs/ontology-overview.md`, `docs/technical-overview.md`, `docs/codebase-overview.md`
+
+## Local Setup (checks first)
+
+- Verify Git identity
+  - Check: `git config --get user.name && git config --get user.email`
+  - If missing: prompt the user to set name/email; do not change config without confirmation.
+- Verify GitHub CLI auth (gh)
+  - Check: `gh auth status`
+  - If not logged in: ask the user “Run gh auth login with SSH now?” and proceed only on approval.
+  - Optional SSH test: `ssh -T git@github.com` (will prompt on first use).
+- Verify Docker availability
+  - Check: `docker version`
+  - If unavailable: inform the user and ask whether to install/continue without local tooling.
+- Verify tooling image
+  - Check: `tooling/run_ontology_tools.sh build` only after confirming Docker is available (safe to run multiple times; uses cache).
+- Repository sanity checks
+  - Syntax/profile: `tooling/run_ontology_tools.sh check-syntax mhm_ontology.owl && tooling/run_ontology_tools.sh profile mhm_ontology.owl DL`
+  - Validators: `tooling/run_ontology_tools.sh validate-units && tooling/run_ontology_tools.sh validate-sosa && tooling/run_ontology_tools.sh validate-skos && tooling/run_ontology_tools.sh validate-prov`
+  - If any fail: surface the failure succinctly and ask whether to investigate now or proceed with planned task.
+
+## Workflow: Issues → Branch → PR
+
+- Plan: create or reference a GitHub Issue describing the task and acceptance checks; link related items in `AGENT-PLAN.md`.
+  - Before starting: search for an existing Issue (`gh issue list --search "<keywords>"`) and link it.
+  - If none exists: ask the user for confirmation, then create one (`gh issue create --title "type(scope): subject" --body "- Goal: …\n- Acceptance: …"`).
+- Branch naming:
+  - `feature/<topic>` for features/modeling
+  - `fix/<topic>` for bug fixes
+  - `docs/<topic>` for documentation
+  - `chore/<topic>` for tooling/infra
+- Local changes: keep scoped; update docs/examples/queries and `AGENT-PLAN.md` when relevant; run validators locally.
+- Commit routine: clear, imperative subjects; group related changes.
+  - Examples: `feature(skos): add Question Domain scheme`, `docs(readme): clarify namespaces`, `fix(queries): prefer odim: prefix`
+- Push and PR with `gh`:
+  - `git push -u origin <branch>`
+  - Name PRs for squash merges using "Type/topic" format. The PR title becomes the squash commit subject:
+    - Preferred: `Feature/<topic>`, `Fix/<topic>`, `Docs/<topic>`, `Chore/<topic>`, `CI/<topic>`
+    - Examples:
+      - `Feature/odim-mh branding (#5)`
+      - `Feature/docs overview (#4)`
+      - `Chore/ci validators (#9)`
+    - If using Conventional Commits during development (`type(scope): subject`), convert to the above for the PR title before squashing.
+  - Include commit summaries in the squash message: when clicking “Squash and merge”, expand “Commit message” and keep the auto‑generated list of commits (or add a concise bullet list yourself).
+  - Repo default for squash messages: this repo is configured to prefill the squash commit title with the PR title and the body with the list of commit messages. To change defaults:
+    - `gh api -X PATCH repos <OWNER>/<REPO> -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=COMMIT_MESSAGES`
+    - Allowed values:
+      - `squash_merge_commit_title`: `PR_TITLE` or `COMMIT_OR_PR_TITLE`
+      - `squash_merge_commit_message`: `PR_BODY`, `COMMIT_MESSAGES`, or `BLANK`
+  - Agent-generated squash messages: agents should explicitly provide a curated squash body that starts with a one-line change summary followed by detailed bullets. Keep the auto-generated commit list only if it adds value beyond the curated bullets.
+    - Recommended structure for the squash message body:
+      - First line: `<area>: <short change summary>`
+        - Example: `branding: adopt ODIM-MH name and odim: prefix (no IRI changes)`
+      - Then a concise bullet list of notable changes:
+        - `- Set ontology label/title to ODIM-MH`
+        - `- Add odim: prefix mapped to CONNECT base`
+        - `- Prefer odim: in examples, vocab, queries`
+        - `- Update README and docs to reference ODIM-MH`
+        - `- Narrow validate-prov to queries/prov_*.rq`
+      - Close with issue linkage if not already: `Closes #NN`.
+    - CLI example to merge with curated subject/body (use different envs/users as needed):
+      - `SUBJ=$(gh pr view <PR#> -q .title --json title)`
+      - `BODY=$'branding: adopt ODIM-MH name and odim: prefix (no IRI changes)\n\n- Set ontology label/title to ODIM-MH\n- Add odim: prefix mapped to CONNECT base\n- Prefer odim: in examples, vocab, queries\n- Update README and docs to reference ODIM-MH\n- Narrow validate-prov to queries/prov_*.rq\n\nCloses #NN'`
+      - `gh pr merge <PR#> --squash --subject "$SUBJ" --body "$BODY"`
+  - Create PR with a multiline body using one of:
+    - `$'...'` quoting (expands newlines):
+      - `gh pr create --base main --title "type(scope): subject" --body $'Closes #NN\n\nSummary line 1\n\nDetails line 2'`
+    - Body file (robust for longer text):
+      - `cat > /tmp/pr_body.md <<'EOF'` then write content, end with `EOF`
+      - `gh pr create --base main --title "type(scope): subject" --body-file /tmp/pr_body.md`
+  - Link issue in body (e.g., `Closes #123`); `gh pr ready` when reviewable
+  - Include the task's Acceptance checklist in the PR body for reviewers
+  - Optional: add labels to the PR (mirrors issue triage)
+    - `gh pr edit <PR#> --add-label "type: ci" --add-label "scope: gh-setup"`
+- PR checklist:
+  - [ ] Syntax/profile pass
+  - [ ] All validators pass: units / sosa / skos / prov
+  - [ ] Docs updated (README, `docs/*.md`), examples/queries adjusted if impacted
+  - [ ] `AGENT-PLAN.md` updated if scope touches roadmap
+  - Branch lifecycle after merge
+   - Confirm the PR is merged (via GitHub UI or `gh pr view --web`)
+   - Delete remote branch: `git push origin --delete <branch>`
+   - Delete local branch: `git branch -d <branch>`
+   - Each task lives in its own short‑lived branch
+### Note on public plan
+- For non‑agentic work, update `plan.md` via a docs‑only PR first (authoritative plan), then record execution notes in `AGENT-PLAN.md`.
+
+### Task selection and user consultation
+- Present 2–4 viable options from `AGENT-PLAN.md` (e.g., A1 Pages landing, A5 CI for latest, B3 CI validators, or a small ontology fix), with one‑line impact summaries.
+- If the user has a preference, follow it. If unclear, propose a default that unblocks the next phase (e.g., A1, then A2/A5).
+- Ask only essential clarifying questions. Assume sufficient context from this repo + AGENTS/PLAN; avoid trivia.
+
+## Maintaining the Plan (AGENT-PLAN.md)
+
+- Purpose: orient contributors and provide assignable tasks; keep concise and current.
+- Structure: Context snapshot, Public plan mirror/sync, Part A (Public‑facing), Part B (GitHub setup), Part C (Namespace migration prep).
+- Add a task using this template:
+  - Title: `type(scope): subject` (e.g., `docs(pages): add index.html`)
+  - Context: why this is needed now, links to files
+  - Goal: one‑sentence outcome
+  - Steps: numbered, actionable list
+  - Acceptance: clear checks (URLs exist, validators pass, settings applied)
+  - Deliverables: files/paths updated, PR link, Issue number
+- Linkage:
+  - Public tasks MUST first be added to `plan.md` via docs PR (authoritative plan), then referenced in AGENT‑PLAN.md with execution notes.
+  - Create an Issue for each task and add `(Issue #NN)` next to the plan line in `plan.md`.
+  - In the PR body include `Closes #NN` to auto‑close on merge.
+  - Label issues/PRs for triage and scope (examples):
+    - `gh issue edit <NN> --add-label "type: ci" --add-label "scope: gh-setup"`
+    - `gh pr edit <NN> --add-label "type: ci" --add-label "scope: gh-setup"`
+  - Commit cadence for plan and features:
+    - Make small, frequent commits on feature branches; push early and keep PRs open.
+    - After completing a feature slice, add a separate commit updating `AGENT-PLAN.md` (Working Branches Log, notes). Keep plan/docs commits separate from ontology/code changes.
+    - For public plan updates, open a docs‑only PR to `plan.md` first, then reference it from `AGENT-PLAN.md`.
+- Example entry:
+  - docs(pages): add index.html (Issue #42)
+    - Context: publish minimal landing for GitHub Pages
+    - Goal: landing page with links to docs and artifacts
+    - Steps: create `docs/index.html`; add links; commit on `docs/pages-landing`
+    - Acceptance: `https://…/MHM-ontology/` loads; links work
+    - Deliverables: `docs/index.html`, PR #.., Closes #42
+
+### Working Branches Log (local)
+- Keep a short list in `AGENT-PLAN.md` to coordinate across agents (example):
+  - [ ] branch: `docs/pages-landing` → PR #___ (open) — owner: @handle
+  - [ ] branch: `chore/ci-validators` → PR #___ (open) — owner: @handle
+- [x] branch: `feature/odim-branding-phase-b` → PR #___ (merged) — owner: @handle (remote/local deleted)
+
+## Labels (conventions)
+
+- Purpose: standardize triage and scope; automation keeps labels in sync.
+- Source of truth: `.github/labels.yml` (synced by `.github/workflows/labels.yml`).
+- Categories to apply on each Issue/PR:
+  - Type: one of `type: feature`, `type: fix`, `type: docs`, `type: chore`, `type: ci`.
+  - Scope: one of `scope: ontology`, `scope: vocab`, `scope: queries`, `scope: tooling`, `scope: docs`, `scope: gh-setup`.
+  - Status: optional workflow indicator `status: needs triage`, `status: in progress`, `status: blocked`, `status: ready for review`.
+- Usage:
+  - Issues: add 1 Type + 1 Scope during triage; update Status as work progresses.
+  - PRs: mirror the linked Issue’s Type/Scope; set `status: ready for review` when handing off.
+  - Commands:
+    - `gh issue edit <NN> --add-label "type: ci" --add-label "scope: gh-setup"`
+    - `gh pr edit <NN> --add-label "type: ci" --add-label "scope: gh-setup"`
+  - Notes: The sync workflow does not prune by default; custom labels remain unless manually removed.
+
+## Ontology Tasks Cheat‑Sheet
+
+## Branch Protection (settings)
+
+- Goal: require PRs and CI to pass before merging into `main`.
+- Required checks (names must match jobs):
+  - `check-syntax`, `profile-dl`, `validate-units`, `validate-sosa`, `validate-skos`, `validate-prov`.
+- GitHub UI path: Settings → Branches → Branch protection rules → Add rule → Branch name pattern `main` → enable:
+  - Require a pull request before merging (min. 1 approving review)
+  - Require status checks to pass before merging, then select the six checks above; require branches up to date.
+  - Require conversation resolution before merging
+  - Do NOT allow force pushes or deletions
+  - Enforce for admins (recommended)
+- CLI (requires admin permission on repo):
+  - `gh pr view 9 --json commits -q '.commits[-1].oid'` then list check runs with `gh api repos <OWNER>/<REPO>/commits/<SHA>/check-runs --jq '.check_runs[].name'` to confirm names.
+  - Apply protection:
+    - `gh api -X PUT repos <OWNER>/<REPO>/branches/main/protection --input protection.json`
+    - Where `protection.json` contains required review and checks configuration; see comments in Issue #11.
+  - Recommended (no local token): use the Branch Protection workflow with a repo secret:
+    - Add repository secret `REPO_ADMIN_TOKEN` (fine‑grained PAT with Administration: write on this repo).
+    - Run the `Branch Protection` workflow (workflow_dispatch). It uses `actions/github-script` with `github-token: ${{ secrets.REPO_ADMIN_TOKEN }}` to call the admin API and apply settings. The secret is masked in logs and not exposed to PRs from forks.
+
+- Core ontology: `mhm_ontology.owl` (DL‑safe); keep imports minimal
+- Examples: `examples.ttl` (ABox, showcase patterns)
+- SKOS vocabularies: `vocab/*.ttl`; tags: `vocab/skos-tags.ttl`
+- SPARQL checks: `queries/*.rq` (ASK queries by topic)
+- Tooling wrapper: `tooling/run_ontology_tools.sh` (profile, report, validators)
+
+## Ontology Change Checklist (TBox/ABox)
+- Add `rdfs:label` (and `skos:prefLabel@en` where using SKOS); optional `IAO:0000115` definition
+- Prefer `odim:` prefix; keep changes DL‑safe; avoid new imports
+- If adding SKOS concepts: include `skos:inScheme`, top concepts if applicable, and language‑tagged labels; extend `queries/skos_*.rq` if needed
+- Update examples to illustrate new patterns; keep examples in `examples.ttl`
+- Add/adjust SPARQL ASK queries to validate new modeling
+- Run all validators and ensure README/docs mention new user‑facing patterns
+
+ 
+
+## Agent Interaction Guidelines
+- Use a checks‑first approach: verify state before proposing actions
+- Be explicit about what you will run; get approval for installs or config changes
+- Summarize options and recommend a default when the path is ambiguous
+- Avoid unnecessary questions; assume the repository + this guide provide sufficient context unless a real blocker emerges
+ - Comments on Issues/PRs: write as the USER addressing repo readers/contributors (not agent→user). Avoid referring to “the agent”; use first‑person where appropriate.
+
+### Admin actions and tokens (one‑off)
+- Some repo settings (e.g., branch protection) require admin permissions. Use a separate admin token only when needed:
+  - Create a fine‑grained PAT: Settings → Developer settings → Fine‑grained tokens
+    - Resource owner: organization owning this repo
+    - Repository access: this repository
+    - Permissions: Administration → Read and write
+  - Preferred: store locally in `.env` (not committed). Use `.env.example` as a template, then:
+    - `cp .env.example .env` and paste the token into `GH_ADMIN_TOKEN=`
+    - Run admin scripts that read the token from `.env`:
+      - `bash tooling/apply_branch_protection.sh`
+  - Alternative (one-off): export in shell for the command: `GH_TOKEN=$GH_ADMIN_TOKEN gh api …`
+
+## Public Website (pre‑w3id)
+
+- Use GitHub Pages (this repo) with `docs/` on `main`
+- Publish:
+  - `docs/index.html` (landing)
+  - `docs/latest/odim-mh.ttl` and `docs/latest/odim-mh.owl` (machine‑readable)
+  - Optional: `docs/releases/vX.Y.Z/…` snapshots; `docs/contexts/odim-mh.jsonld`
+- These will become targets for w3id redirects when the namespace is live
+
+## Safety & Boundaries
+
+- No secrets or personal data in the repo
+- Keep core in OWL DL profile; use separate modules for OWL Full if needed
+- Do not change base IRIs without an approved migration plan (see `AGENT-PLAN.md`)
+
+## Quick Commands
+
+- Build tools: `tooling/run_ontology_tools.sh build`
+- Syntax: `tooling/run_ontology_tools.sh check-syntax mhm_ontology.owl`
+- Profile: `tooling/run_ontology_tools.sh profile mhm_ontology.owl DL`
+- Report: `tooling/run_ontology_tools.sh report mhm_ontology.owl`
+- Validate: `tooling/run_ontology_tools.sh validate-units|validate-sosa|validate-skos|validate-prov`
+
+## Contacts
+
+- Maintainer: @james-c (Mental Health Mission)
+- Organization: Mental Health Mission — mention for reviews as needed
+
+---
+Note: `AGENTS.md` is locally ignored via `.git/info/exclude` to allow iterative drafting. Remove the exclude entry and commit when ready to share.

--- a/tooling/apply_branch_protection.sh
+++ b/tooling/apply_branch_protection.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply branch protection to `main` using GH_ADMIN_TOKEN from env or .env
+# Requirements:
+# - gh CLI installed
+# - Admin token with Administration: Read and write on this repo
+
+here=$(cd "$(dirname "$0")" && pwd)
+root=$(cd "$here/.." && pwd)
+
+# Load .env if present (and not in CI)
+if [ -f "$root/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "$root/.env"
+  set +a
+fi
+
+if [ -z "${GH_ADMIN_TOKEN:-}" ]; then
+  echo "Error: GH_ADMIN_TOKEN is not set. See .env.example."
+  exit 1
+fi
+
+repo=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+echo "Applying protection to $repo:main"
+
+# Discover latest check names from a recent PR (fallback to defaults)
+default_checks=(check-syntax profile-dl validate-units validate-sosa validate-skos validate-prov)
+sha="$(gh api repos/$repo/commits --jq '.[0].sha' | head -n1 || true)"
+checks_json=""
+if [ -n "$sha" ]; then
+  mapfile -t checks < <(GH_TOKEN="$GH_ADMIN_TOKEN" gh api repos/$repo/commits/$sha/check-runs --jq '.check_runs[].name' -H 'Accept: application/vnd.github+json' 2>/dev/null || true)
+fi
+if [ ${#checks[@]:-0} -eq 0 ]; then
+  checks=("${default_checks[@]}")
+fi
+for c in "${checks[@]}"; do
+  checks_json+="{\"context\": \"$c\"},"
+done
+checks_json="${checks_json%,}"
+
+read -r -d '' BODY <<JSON
+{
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "required_approving_review_count": 1,
+    "require_code_owner_reviews": false,
+    "require_last_push_approval": false
+  },
+  "required_status_checks": {
+    "strict": true,
+    "checks": [ $checks_json ]
+  },
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": false,
+  "block_creations": false,
+  "required_conversation_resolution": true,
+  "lock_branch": false
+}
+JSON
+
+GH_TOKEN="$GH_ADMIN_TOKEN" gh api -X PUT repos/$repo/branches/main/protection --input - -H 'Accept: application/vnd.github+json' <<<"$BODY" >/dev/null
+echo "Protection applied. Verifying:"
+GH_TOKEN="$GH_ADMIN_TOKEN" gh api repos/$repo/branches/main/protection --jq '{admins:.enforce_admins,required_reviews:.required_pull_request_reviews.required_approving_review_count,strict:.required_status_checks.strict,checks:(.required_status_checks.checks[]?.context)}'
+


### PR DESCRIPTION
Closes #11

Adds Branch Protection workflow using a repo secret (REPO_ADMIN_TOKEN). Documents token usage and the “never commit directly to main” rule in AGENTS.md. Also adds .env example and a local script for admin calls when needed.