### PR TITLE
Chore/CI: Jena 5.5.0 + dlcdn mirror (fix downloads)

### DIFF
--- a/tooling/Dockerfile
+++ b/tooling/Dockerfile
@@ -2,7 +2,7 @@
 FROM eclipse-temurin:17-jre
 
 ARG ROBOT_VERSION=1.9.6
-ARG JENA_VERSION=4.10.0
+ARG JENA_VERSION=5.5.0
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
@@ -20,9 +20,9 @@ RUN mkdir -p /opt/robot/bin \
     && printf '#!/usr/bin/env bash\nexec java ${ROBOT_JAVA_ARGS:-} -jar /opt/robot/bin/robot.jar "$@"\n' > /opt/robot/bin/robot \
     && chmod +x /opt/robot/bin/robot
 
-# Install Apache Jena (for riot)
+# Install Apache Jena (for riot) — prefer dlcdn, fallback to archive
 RUN (curl -fsSL -o /tmp/jena.tgz \
-      https://downloads.apache.org/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz \
+      https://dlcdn.apache.org/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz \
       || curl -fsSL -o /tmp/jena.tgz \
       https://archive.apache.org/dist/jena/binaries/apache-jena-${JENA_VERSION}.tar.gz) \
     && tar -C /opt -xzf /tmp/jena.tgz \


### PR DESCRIPTION
Summary:
- Bump Apache Jena to 5.5.0
- Switch primary download to dlcdn.apache.org with archive.apache.org fallback

Rationale:
- Previous downloads.apache.org URL for 4.10.0 intermittently 404s on CI.
- Newer Jena versions are available via dlcdn; keeping a stable fallback.

Acceptance:
- CI builds the tooling image successfully on Ubuntu runners
- All jobs (check-syntax, profile-dl, validate-*) pass

Closes #19