### PR TITLE
chore: placeholder (no changes)

### DIFF
--- a/.github/workflows/agent-guard.yml
+++ b/.github/workflows/agent-guard.yml
@@ -1,0 +1,28 @@
+name: Guard Agent-Only Files
+
+on:
+  pull_request:
+
+jobs:
+  block-agent-files:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect prohibited files
+        run: |
+          set -euo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          echo "Comparing $BASE_SHA..$HEAD_SHA"
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          echo "$CHANGED" | sed 's/^/ - /'
+          # Blocklist
+          PROHIBITED_REGEX='^(AGENT-PLAN\.md|\.agents\/|\.agents\/.*)'
+          if echo "$CHANGED" | grep -E "$PROHIBITED_REGEX" >/dev/null; then
+            echo "Error: Agent-only files detected in PR. Remove these from commits:"
+            echo "$CHANGED" | grep -E "$PROHIBITED_REGEX" | sed 's/^/ - /'
+            exit 1
+          fi
+          echo "No agent-only files detected."

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ build/
 
 # Local environment overrides (never commit secrets)
 .env
+# Agent-only local files (must never be committed)
+AGENT-PLAN.md
+.agents/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,8 @@ This guide sets expectations for coding agents and contributors working on ODIMâ
   - Steps: numbered, actionable list
   - Acceptance: clear checks (URLs exist, validators pass, settings applied)
   - Deliverables: files/paths updated, PR link, Issue number
+- Non-negotiable: AGENT-PLAN.md is local-only and MUST NOT be committed to the public repo under any circumstances. A CI guard blocks PRs containing it.
+
 - Linkage:
   - Public tasks MUST first be added to `plan.md` via docs PR (authoritative plan), then referenced in AGENTâ€‘PLAN.md with execution notes.
   - Create an Issue for each task and add `(Issue #NN)` next to the plan line in `plan.md`.
@@ -281,3 +283,11 @@ This guide sets expectations for coding agents and contributors working on ODIMâ
 
 ---
 Note: `AGENTS.md` is locally ignored via `.git/info/exclude` to allow iterative drafting. Remove the exclude entry and commit when ready to share.
+
+Agent sync steps (local-only)
+- Ensure agent-only files are excluded locally:
+  - echo 'AGENT-PLAN.md' >> .git/info/exclude
+  - echo '.agents/' >> .git/info/exclude
+- Verify before committing: git status should never list AGENT-PLAN.md
+- If agent-only files were accidentally staged: git restore --staged AGENT-PLAN.md; git clean -fd .agents/
+- CI guard: PRs touching AGENT-PLAN.md or .agents/ will fail; remove those changes before opening PRs.


### PR DESCRIPTION
Summary:
- Add CI guard to block AGENT-PLAN.md/.agents in PRs
- Add .gitignore entries for agent-only local files
- Clarify policy and local sync steps in AGENTS.md

Rationale:
- Prevent agent-only materials from entering the public repo.
